### PR TITLE
fix(copy link): duration time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recipes",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/common/CopyLinkButton/index.tsx
+++ b/src/app/components/common/CopyLinkButton/index.tsx
@@ -18,7 +18,7 @@ function CopyLinkButton() {
 
     setTimeout(() => {
       setShowMessage(false);
-    }, 2000);
+    }, 4000);
   };
 
   const joinedClassName = joinClassNames(


### PR DESCRIPTION
This pull request includes two key changes: a version update in the `package.json` file and an adjustment to the timeout duration in the `CopyLinkButton` component.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.5.1` to `1.6.1`, likely indicating new features or improvements.

### UI behavior adjustment:
* [`src/app/components/common/CopyLinkButton/index.tsx`](diffhunk://#diff-8bcb809e64a3835b0ca2621cb13dbd918d6a8b5bb24397fc0436f704d0a01b6bL21-R21): Increased the timeout duration for hiding the confirmation message from 2000ms to 4000ms, likely to improve user experience by giving users more time to see the message.