### PR TITLE
fix: avoid duplicate frontend refetch by using getQueryClient in server components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "recipes",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recipes",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@next/third-parties": "^15.0.4",
-        "@tanstack/react-query": "^5.62.8",
-        "@tanstack/react-query-devtools": "^5.62.8",
+        "@tanstack/react-query": "^5.74.11",
+        "@tanstack/react-query-devtools": "^5.74.11",
         "browser-image-compression": "^2.0.2",
         "dayjs": "^1.11.13",
         "heic2any": "^0.0.4",
@@ -1191,32 +1191,29 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.62.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.8.tgz",
-      "integrity": "sha512-4fV31vDsUyvNGrKIOUNPrZztoyL187bThnoQOvAXEVlZbSiuPONpfx53634MKKdvsDir5NyOGm80ShFaoHS/mw==",
-      "license": "MIT",
+      "version": "5.74.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.9.tgz",
+      "integrity": "sha512-qmjXpWyigDw4SfqdSBy24FzRvpBPXlaSbl92N77lcrL+yvVQLQkf0T6bQNbTxl9IEB/SvVFhhVZoIlQvFnNuuw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.61.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.61.4.tgz",
-      "integrity": "sha512-21Tw+u8E3IJJj4A/Bct4H0uBaDTEu7zBrR79FeSyY+mS2gx5/m316oDtJiKkILc819VSTYt+sFzODoJNcpPqZQ==",
-      "license": "MIT",
+      "version": "5.74.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.74.7.tgz",
+      "integrity": "sha512-nSNlfuGdnHf4yB0S+BoNYOE1o3oAH093weAYZolIHfS2stulyA/gWfSk/9H4ZFk5mAAHb5vNqAeJOmbdcGPEQw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.62.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.8.tgz",
-      "integrity": "sha512-8TUstKxF/fysHonZsWg/hnlDVgasTdHx6Q+f1/s/oPKJBJbKUWPZEHwLTMOZgrZuroLMiqYKJ9w69Abm8mWP0Q==",
-      "license": "MIT",
+      "version": "5.74.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.11.tgz",
+      "integrity": "sha512-FFhn9ZiYRUOsxLAWZYxVfQTpVE7UWRaAeHJIWVDHKlmZZGc16rMHW9KrFZ8peC4hA71QUf/shJD8dPSMqDnRmA==",
       "dependencies": {
-        "@tanstack/query-core": "5.62.8"
+        "@tanstack/query-core": "5.74.9"
       },
       "funding": {
         "type": "github",
@@ -1227,19 +1224,18 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.62.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.62.8.tgz",
-      "integrity": "sha512-SwjXjQTRONd9WPeKVQQ9framG7YNqPV8PS+EGNVNXAyz2XThulMRCvZnh2+3DggnjcYM7YcpnuoZ4RH7q13p0g==",
-      "license": "MIT",
+      "version": "5.74.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.74.11.tgz",
+      "integrity": "sha512-vx8MzH4WUUk4ZW8uHq7T45XNDgePF5ecRoa7haWJZxDMQyAHM80GGMhEW/yRz6TeyS9UlfTUz2OLPvgGRvvVOA==",
       "dependencies": {
-        "@tanstack/query-devtools": "5.61.4"
+        "@tanstack/query-devtools": "5.74.7"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.62.8",
+        "@tanstack/react-query": "^5.74.11",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recipes",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@next/third-parties": "^15.0.4",
-    "@tanstack/react-query": "^5.62.8",
-    "@tanstack/react-query-devtools": "^5.62.8",
+    "@tanstack/react-query": "^5.74.11",
+    "@tanstack/react-query-devtools": "^5.74.11",
     "browser-image-compression": "^2.0.2",
     "dayjs": "^1.11.13",
     "heic2any": "^0.0.4",

--- a/src/app/sn/products/[productKey]/ProductPageContainer.tsx
+++ b/src/app/sn/products/[productKey]/ProductPageContainer.tsx
@@ -1,11 +1,11 @@
 import {
   dehydrate,
   HydrationBoundary,
-  QueryClient,
   queryOptions,
 } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 
+import { getQueryClient } from '@/queries/get-query-client';
 import {
   productOptions,
   productRecommendOptions,
@@ -23,7 +23,7 @@ interface Props {
 function ProductPageContainer({ productKey }: Props) {
   if (!productKey) notFound();
 
-  const queryClient = new QueryClient();
+  const queryClient = getQueryClient();
 
   queryClient.prefetchQuery(
     queryOptions(productOptions({ key: productKey, enabled: true })),

--- a/src/app/sn/recipes/[recipeKey]/RecipePageContainer.tsx
+++ b/src/app/sn/recipes/[recipeKey]/RecipePageContainer.tsx
@@ -1,11 +1,11 @@
 import {
   dehydrate,
   HydrationBoundary,
-  QueryClient,
   queryOptions,
 } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 
+import { getQueryClient } from '@/queries/get-query-client';
 import { recipeOptions, recipeRecommendOptions } from '@/queries/options';
 
 import Recipe from './Recipe';
@@ -14,7 +14,7 @@ import Recommend from './Recommend';
 function RecipePageContainer({ recipeKey }: { recipeKey: string }) {
   if (!recipeKey) notFound();
 
-  const queryClient = new QueryClient();
+  const queryClient = getQueryClient();
 
   queryClient.prefetchQuery(queryOptions(recipeOptions({ key: recipeKey })));
   queryClient.prefetchQuery(

--- a/src/app/sn/users/[username]/page.tsx
+++ b/src/app/sn/users/[username]/page.tsx
@@ -1,12 +1,12 @@
 import {
   dehydrate,
   HydrationBoundary,
-  QueryClient,
   queryOptions,
 } from '@tanstack/react-query';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+import { getQueryClient } from '@/queries/get-query-client';
 import {
   productsOptions,
   recipesOptions,
@@ -68,7 +68,7 @@ async function UserPage({ params }: Props) {
   const { username } = await params;
   if (!username) return notFound();
 
-  const queryClient = new QueryClient();
+  const queryClient = getQueryClient();
 
   queryClient.prefetchQuery(
     queryOptions(


### PR DESCRIPTION
# Summary

This PR fixes an issue where the same API request was being fetched twice—once on the server and again on the client—even when using useSuspenseQuery with prefetchQuery + HydrationBoundary.

# Root Cause

The server component was using a newly created QueryClient instead of the shared instance provided by the `getQueryClient()` utility. As a result, the dehydrated state from prefetchQuery was not reused properly in the browser, leading to unnecessary refetching.

# Fix

Replaced direct instantiation of QueryClient with getQueryClient() inside the server component (RecipePageContainer), ensuring consistent client usage across server and client environments.

# Related Code Snippet
```
// ❌ Old: created a new QueryClient directly
const queryClient = new QueryClient(); 

// ✅ New: use shared instance-aware client
const queryClient = getQueryClient();
```

# Result

With this change:
- The server-rendered data is properly hydrated into the browser
- No unnecessary refetch happens on the client
- Improved SSR+CSR consistency and performance

# Upgrade dependencies
- @tanstack/react-query: 5.62.8 -> 5.74.11
- @tanstack/react-query-devtools: 5.62.8 -> 5.74.11