### PR TITLE
fix: user profile page - update staleTime for user profile apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recipes",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/sn/users/[username]/UserContent/RecipeList.tsx
+++ b/src/app/sn/users/[username]/UserContent/RecipeList.tsx
@@ -24,6 +24,7 @@ function RecipeList() {
         query: params.username,
         type: 'username',
         enabled: isUserProfile,
+        staleTime: 1000 * 60 * 60, // 1 hour
       })}
       fallback={<CardListSkeleton count={5} />}
       errorFallback={() => <p>Failed to get recipes.</p>}

--- a/src/app/sn/users/[username]/UserProfile/index.tsx
+++ b/src/app/sn/users/[username]/UserProfile/index.tsx
@@ -26,6 +26,7 @@ function UserProfile() {
       {...profileOptions({
         username: params.username,
         enabled: isUserProfile,
+        staleTime: 1000 * 60 * 60, // 1 hour
       })}
       errorFallback={() => notFound()}
       fallback={<UserProfileBodySkeleton />}

--- a/src/app/sn/users/[username]/page.tsx
+++ b/src/app/sn/users/[username]/page.tsx
@@ -74,7 +74,6 @@ async function UserPage({ params }: Props) {
     queryOptions(
       profileOptions({
         username,
-        staleTime: 180000, // 3 minutes
       }),
     ),
   );
@@ -83,7 +82,6 @@ async function UserPage({ params }: Props) {
       recipesOptions({
         query: username,
         type: 'username',
-        staleTime: 180000, // 3 minutes
       }),
     ),
   );
@@ -92,7 +90,6 @@ async function UserPage({ params }: Props) {
       productsOptions({
         type: PRODUCT_TYPES.USERNAME,
         q: username,
-        staleTime: 180000, // 3 minutess
       }),
     ),
   );


### PR DESCRIPTION
This pull request standardizes the cache `staleTime` across the user-related components in the application, ensuring consistent behavior and improving maintainability. The `staleTime` for certain queries has been increased from 3 minutes to 1 hour, while redundant `staleTime` definitions have been removed from the `UserPage` component.

### Standardization of `staleTime`:

* `src/app/sn/users/[username]/UserContent/RecipeList.tsx`: Added a `staleTime` of 1 hour to the `recipesOptions` query in the `RecipeList` component. ([src/app/sn/users/[username]/UserContent/RecipeList.tsxR27](diffhunk://#diff-a0318a0a1e2b538f322f2ea09c8afab3cb7d033e558d31ce05d8094c4e4812c4R27))
* `src/app/sn/users/[username]/UserProfile/index.tsx`: Added a `staleTime` of 1 hour to the `profileOptions` query in the `UserProfile` component. ([src/app/sn/users/[username]/UserProfile/index.tsxR29](diffhunk://#diff-62a0f15e9c4053d4b5acc9404afa483f0f5b96f12aec7e26fd67fff10b317ebeR29))

### Removal of redundant `staleTime` definitions:

* `src/app/sn/users/[username]/page.tsx`: Removed the `staleTime` of 3 minutes from the `profileOptions`, `recipesOptions`, and `productsOptions` queries in the `UserPage` component. These definitions are now standardized elsewhere. ([src/app/sn/users/[username]/page.tsxL77](diffhunk://#diff-9fb7f16f51c60d833afc9ada6122360b6e33fea30924bb58bddc5f76c2ae2ee6L77), [src/app/sn/users/[username]/page.tsxL86](diffhunk://#diff-9fb7f16f51c60d833afc9ada6122360b6e33fea30924bb58bddc5f76c2ae2ee6L86), [src/app/sn/users/[username]/page.tsxL95](diffhunk://#diff-9fb7f16f51c60d833afc9ada6122360b6e33fea30924bb58bddc5f76c2ae2ee6L95))…ies to 1 hour