### PR TITLE
Fix: Recipe updates not reflecting on user profile page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recipes",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/sn/users/[username]/UserContent/ProductList.tsx
+++ b/src/app/sn/users/[username]/UserContent/ProductList.tsx
@@ -25,6 +25,8 @@ function ProductList() {
         type: PRODUCT_TYPES.USERNAME,
         q: params.username || '',
         enabled: isUserProfile,
+        staleTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
+        gcTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
       })}
       errorFallback={() => <p>Failed to get products.</p>}
       fallback={<ProductCardsSkeleton />}

--- a/src/app/sn/users/[username]/UserContent/RecipeList.tsx
+++ b/src/app/sn/users/[username]/UserContent/RecipeList.tsx
@@ -24,7 +24,8 @@ function RecipeList() {
         query: params.username,
         type: 'username',
         enabled: isUserProfile,
-        staleTime: 1000 * 60 * 60, // 1 hour
+        staleTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
+        gcTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
       })}
       fallback={<CardListSkeleton count={5} />}
       errorFallback={() => <p>Failed to get recipes.</p>}

--- a/src/app/sn/users/[username]/UserProfile/index.tsx
+++ b/src/app/sn/users/[username]/UserProfile/index.tsx
@@ -26,7 +26,8 @@ function UserProfile() {
       {...profileOptions({
         username: params.username,
         enabled: isUserProfile,
-        staleTime: 1000 * 60 * 60, // 1 hour
+        staleTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
+        gcTime: isUserProfile ? 0 : 1000 * 60 * 60, // 1 hour
       })}
       errorFallback={() => notFound()}
       fallback={<UserProfileBodySkeleton />}

--- a/src/queries/options/products/productsOptions.ts
+++ b/src/queries/options/products/productsOptions.ts
@@ -7,6 +7,7 @@ interface Props {
   q: string;
   initialData?: Product[];
   staleTime?: number;
+  gcTime?: number;
   type: ProductQueryTypes;
   enabled?: boolean;
   nextRevalidateTime?: number;
@@ -15,6 +16,7 @@ interface Props {
 export const productsOptions = ({
   initialData,
   staleTime = 86400000, // 24 hours , MS
+  gcTime = 86400000, // 24 hours , MS
   type,
   nextRevalidateTime = 86400, // 24 hours , S
   q,
@@ -39,5 +41,6 @@ export const productsOptions = ({
   },
   initialData,
   staleTime,
+  gcTime,
   enabled: !!enabled,
 });

--- a/src/queries/options/recipes/recipesOptions.ts
+++ b/src/queries/options/recipes/recipesOptions.ts
@@ -8,12 +8,14 @@ interface RecipeListOptions {
   type: RecipesSearchType;
   staleTime?: number;
   enabled?: boolean;
+  gcTime?: number;
 }
 
 export const recipesOptions = ({
   query,
   type,
   staleTime,
+  gcTime,
   enabled,
 }: RecipeListOptions) => ({
   queryKey: queryKeys.recipes.list({ query, type }),
@@ -25,5 +27,6 @@ export const recipesOptions = ({
     return result.data;
   },
   staleTime,
+  gcTime,
   enabled: !!enabled,
 });

--- a/src/queries/options/users/profileOptions.ts
+++ b/src/queries/options/users/profileOptions.ts
@@ -6,12 +6,14 @@ interface ProfileOptions {
   username: string;
   enabled?: boolean;
   staleTime?: number;
+  gcTime?: number;
 }
 
 export const profileOptions = ({
   username,
   enabled,
   staleTime,
+  gcTime,
 }: ProfileOptions) => ({
   queryKey: queryKeys.users.user.profile(username),
   queryFn: async () => {
@@ -23,4 +25,5 @@ export const profileOptions = ({
   },
   enabled,
   staleTime,
+  gcTime,
 });


### PR DESCRIPTION
This pull request resolves an issue where recipe updates weren't immediately visible on the user's profile page after editing.

**Problem**:
When a user updated their recipe post, the changes weren't reflected on their profile page due to stale cached data.
Even react query was used when it was fetched from server data, it used server data cache. So, needed to make client not use the data that next server sent and make it refetch in client.

**Solution**:
Implemented dynamic gcTime configuration based on profile ownership:

Own profile: `gcTime: 0` 
- Forces immediate data fetching to ensure users always see their latest changes
Other users' profiles: `gcTime: 24 hours `
- Maintains cached data for better performance since real-time updates aren't critical for viewing others' profiles

This approach balances user experience (immediate updates for own content) with performance optimization (efficient caching for browsing other profiles).

### Updates to Query Options:

* `src/queries/options/products/productsOptions.ts`:
  - Added a `gcTime` parameter to the `Props` interface and the `productsOptions` function, with a default value of 24 hours (86400000 ms). [[1]](diffhunk://#diff-2ee838dcc48c99ca92418c8dd0114cd7c01bfcaa7384ad18168233f5744a4f31R10) [[2]](diffhunk://#diff-2ee838dcc48c99ca92418c8dd0114cd7c01bfcaa7384ad18168233f5744a4f31R19) [[3]](diffhunk://#diff-2ee838dcc48c99ca92418c8dd0114cd7c01bfcaa7384ad18168233f5744a4f31R44)

* `src/queries/options/recipes/recipesOptions.ts`:
  - Introduced the `gcTime` parameter in the `RecipeListOptions` interface and the `recipesOptions` function. [[1]](diffhunk://#diff-d04df0a709f824efd48779d0fc0c70d6c4da5a21d2e74c5c4a8ef402c1888cc9R11-R18) [[2]](diffhunk://#diff-d04df0a709f824efd48779d0fc0c70d6c4da5a21d2e74c5c4a8ef402c1888cc9R30)

* `src/queries/options/users/profileOptions.ts`:
  - Added the `gcTime` parameter to the `ProfileOptions` interface and the `profileOptions` function. [[1]](diffhunk://#diff-4bfc0813e0bf64eeb3e6e41f2da5de4a4f68040f1421d25ad8efb4be1882853eR9-R16) [[2]](diffhunk://#diff-4bfc0813e0bf64eeb3e6e41f2da5de4a4f68040f1421d25ad8efb4be1882853eR28)

### Component-Specific Updates:

* `src/app/sn/users/[username]/UserContent/ProductList.tsx`:
  - Updated the query options to include `gcTime`, with conditional values based on whether the view is a user profile (`isUserProfile`). ([src/app/sn/users/[username]/UserContent/ProductList.tsxR28-R29](diffhunk://#diff-11cbb94d61e2a7cac1d85f35999335c89d08e5a3fee55aff0034782a9825ac1bR28-R29))

* `src/app/sn/users/[username]/UserContent/RecipeList.tsx`:
  - Modified the query options to use the new `gcTime` parameter, similar to the `ProductList` component. ([src/app/sn/users/[username]/UserContent/RecipeList.tsxL27-R28](diffhunk://#diff-a0318a0a1e2b538f322f2ea09c8afab3cb7d033e558d31ce05d8094c4e4812c4L27-R28))

* `src/app/sn/users/[username]/UserProfile/index.tsx`:
  - Incorporated the `gcTime` parameter into the query options, with logic dependent on the `isUserProfile` flag. ([src/app/sn/users/[username]/UserProfile/index.tsxL29-R30](diffhunk://#diff-62a0f15e9c4053d4b5acc9404afa483f0f5b96f12aec7e26fd67fff10b317ebeL29-R30))